### PR TITLE
Fix duplicate kubernetes-admin users

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "kind-cluster-provider",
+    "name": "kind-vscode",
     "version": "0.0.1",
     "lockfileVersion": 1,
     "requires": true,
@@ -1509,6 +1509,11 @@
             "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
             "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
             "dev": true
+        },
+        "replace-string": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/replace-string/-/replace-string-3.0.0.tgz",
+            "integrity": "sha512-jE5X/k3p2v8p6+wxhM1Ti0Oj9lYtwPbMj0ty8iSFpAFIihkiNpl6uHgYW1De/r9DG3vA7HGIgIBMjlwJZXL02w=="
         },
         "request": {
             "version": "2.88.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
         "@types/shelljs": "^0.8.3"
     },
     "dependencies": {
+        "replace-string": "^3.0.0",
         "shelljs": "^0.8.3",
         "vscode-kubernetes-tools-api": "^1.0.0"
     }

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,0 +1,13 @@
+import replaceString = require('replace-string');
+
+declare global {
+    interface String {
+        replaceAll(search: string, replacement: string): string;
+    }
+}
+
+if (!String.prototype.replaceAll) {
+    String.prototype.replaceAll = function(this: string, search: string, replacement: string) {
+        return replaceString(this, search, replacement);
+    };
+}


### PR DESCRIPTION
`kind get kubeconfig` always returns a kubeconfig with the user name `kubernetes-admin`.  This causes duplication errors if we try to merge more than one Kind context to the main kubeconfig.  This PR munges the kubeconfig YAML before returning it to the Kubernetes extension, so that users can merge multiple Kind clusters and not have them clash.